### PR TITLE
fix(phpQuery/DOMDocumentWrapper.php): fix extra charsetFixHTML().

### DIFF
--- a/phpQuery/phpQuery/DOMDocumentWrapper.php
+++ b/phpQuery/phpQuery/DOMDocumentWrapper.php
@@ -141,8 +141,10 @@ class DOMDocumentWrapper {
 		$documentCharset = $this->charsetFromHTML($markup);
 		$addDocumentCharset = false;
 		if ($documentCharset) {
-			$charset = $documentCharset;
-			$markup = $this->charsetFixHTML($markup);
+                  $charset = $documentCharset;
+                  if ( strcasecmp($documentCharset, phpQuery::$defaultCharset) != 0 ) {
+                    $markup = $this->charsetFixHTML($markup);
+                  }
 		} else if ($requestedCharset) {
 			$charset = $requestedCharset;
 		}

--- a/phpQuery/phpQuery/DOMDocumentWrapper.php
+++ b/phpQuery/phpQuery/DOMDocumentWrapper.php
@@ -141,10 +141,10 @@ class DOMDocumentWrapper {
 		$documentCharset = $this->charsetFromHTML($markup);
 		$addDocumentCharset = false;
 		if ($documentCharset) {
-                    $charset = $documentCharset;
-                    if ( strcasecmp($documentCharset, phpQuery::$defaultCharset) != 0 ) {
-                        $markup = $this->charsetFixHTML($markup);
-                    }
+                        $charset = $documentCharset;
+                        if ( strcasecmp($documentCharset, phpQuery::$defaultCharset) != 0 ) {
+                            $markup = $this->charsetFixHTML($markup);
+                        }
 		} else if ($requestedCharset) {
 			$charset = $requestedCharset;
 		}

--- a/phpQuery/phpQuery/DOMDocumentWrapper.php
+++ b/phpQuery/phpQuery/DOMDocumentWrapper.php
@@ -141,10 +141,10 @@ class DOMDocumentWrapper {
 		$documentCharset = $this->charsetFromHTML($markup);
 		$addDocumentCharset = false;
 		if ($documentCharset) {
-                  $charset = $documentCharset;
-                  if ( strcasecmp($documentCharset, phpQuery::$defaultCharset) != 0 ) {
-                    $markup = $this->charsetFixHTML($markup);
-                  }
+                    $charset = $documentCharset;
+                    if ( strcasecmp($documentCharset, phpQuery::$defaultCharset) != 0 ) {
+                        $markup = $this->charsetFixHTML($markup);
+                    }
 		} else if ($requestedCharset) {
 			$charset = $requestedCharset;
 		}


### PR DESCRIPTION
Summary: Fix wrong text-presentation news from setn.com 


**Current status screenshot about the problem:**
![截圖 2021-02-20 下午10 57 13](https://user-images.githubusercontent.com/953536/108603239-de56d300-73e1-11eb-9a94-aff45a07ef08.png)



**Root cause:**
Current content’s status(Date: 20210220) of setn.com always let phpQuery doing unwanted things.
Before this week, the status seems has no this behavior. The file: DOMDocumentWrapper.php under phpQuery directory will fix content of HTML’s encoding to utf-8 even it has been utf-8 using charsetFixHTML() from line 143 to 145. The charsetFixHTML() does wrong thing for setn.com. 

**Solution:**
Only to use charsetFixHTML() if encoding of HTML is different with phpQuery’s default one. Default encoding of phpQuery is utf-8. So we will add extra check condition before using charsetFixHTML().


**Root cause analysis:** 
Following I state are mainly focused on loadMarkupHTML() at DOMDocumentWrapper.php.

The content of setn.com is already been overflowed after using charsetFixHTML() so loadHTML()  executing at line 198 and 199 presents human-unreadable text.

The execution functions for both of setn.com and chinatimes, which I use it as a control group, at DOMDocumentWrapper.php are load(), loadMarkup() and loadMarkupHTML() at line 116.

_Compare to chinatimes:_
HTML of Chinatimes has no encoding so phpQuery considers it as ISO-8859-1 and then executes code of line 146 to 148 and line 191 to 194. So the content of chinatimes be converted from ISO-8859-1 to utf-8 whose related code you can read are at line 133, 140, 146 to 156, and 190 to 199.   

